### PR TITLE
switch matrix to non-transpose so model is matrix times colvec

### DIFF
--- a/R/iterate_matrix.R
+++ b/R/iterate_matrix.R
@@ -236,7 +236,7 @@ tf_iterate_matrix <- function (mat, state, niter) {
 
   # iterate the matrix, storing states in a list
   for (i in seq_len(niter))
-    states[[i + 1]] <-  tf$matmul(mat, states[[i]], transpose_a = TRUE)
+    states[[i + 1]] <-  tf$matmul(mat, states[[i]], transpose_a = FALSE)
 
   # return all the states
   states


### PR DESCRIPTION
model is now matrix(transitions) * col_vec(states) rather than row_vec(states) * matrix(transitions). Could possibly pass this as an argument to tf_iterate_matrix from iterate_matrix?