### PR TITLE
Tf while loop

### DIFF
--- a/man/iterate_matrix.Rd
+++ b/man/iterate_matrix.Rd
@@ -5,7 +5,7 @@
 \title{iterate transition matrices}
 \usage{
 iterate_matrix(matrix, initial_state = rep(1, ncol(matrix)),
-  niter = 100)
+  niter = 100, tol = 1e-06)
 }
 \arguments{
 \item{matrix}{either a square 2D transition matrix (with dimensions m x m),
@@ -16,32 +16,56 @@ matrices to iterate}
 (with dimensions n x m x 1) giving one or more initial states from which to
 iterate the matrix}
 
-\item{niter}{a positive integer giving the number of times to iterate the
-matrix}
+\item{niter}{a positive integer giving the maximum number of times to iterate
+the matrix}
+
+\item{tol}{a scalar giving a numerical tolerance, below which the algorithm
+is determineed to have converged to the same growth rate in all stages}
 }
 \value{
-a named list with three greta arrays: \code{lambda} a scalar or
-  vector giving the ratio of the first stage values between the final two
-  iterations, \code{stable_state} a vector or matrix (with the same
-  dimensions as \code{initial_state}) giving the state after the final
-  iteration, normalised so that the values for all stages sum to one, and
-  \code{all_states} an n x m x niter matrix of the state values at each
-  iteration. If the system has converged in \code{niter} iterations,
-  \code{lambda} and \code{stable_state} correspond to the asymptotic growth
-  rate and stable stage distribution respectively.
+a named list with five greta arrays:
+\itemize{
+  \item{\code{lambda}} {a scalar or vector giving the ratio of the first stage
+  values between the final two iterations.}
+  \item{\code{stable_state}} {a vector or matrix (with the same dimensions as
+  \code{initial_state}) giving the state after the final iteration,
+  normalised so that the values for all stages sum to one.}
+  \item{\code{all_states}} {an n x m x niter matrix of the state values at
+  each iteration. This will be 0 for all entries after \code{iterations}.}
+  \item{\code{converged}} {an integer scalar indicating whether \emph{all}
+  the matrix iterations converged to a tolerance less than \code{tol} (1 if
+  so, 0 if not) before the algorithm finished.}
+  \item{\code{iterations}} {a scalar of the maximum number of iterations
+  completed before the algorithm terminated. This should match \code{niter}
+  if \code{converged} is \code{FALSE}.}
+}
 }
 \description{
-calculate the intrinsic growth rate(s) and stable stage
+Calculate the intrinsic growth rate(s) and stable stage
   distribution(s) for a stage-structured dynamical system, encoded as a
-  transition matrix
+  transition matrix.
 }
 \details{
-\code{iterate_matrix} can either act on single transition matrix and
-  initial state (if \code{matrix} is 2D and \code{initial_state} is a column
-  vector), or it can simultaneously act on \emph{n} different matrices and/or
-  \emph{n} different initial states (if \code{matrix} and
+\code{iterate_matrix} can either act on a single transition matrix
+  and initial state (if \code{matrix} is 2D and \code{initial_state} is a
+  column vector), or it can simultaneously act on \emph{n} different matrices
+  and/or \emph{n} different initial states (if \code{matrix} and
   \code{initial_state} are 3D arrays). In the latter case, the first
   dimension of both objects should be the batch dimension \emph{n}.
+
+  To ensure the matrix is iterated for a specific number of iterations, you
+  can set that number as \code{niter}, and set \code{tol} to 0 or a negative
+  number to ensure that the iterations are not stopped early.
+}
+\note{
+because greta vectorises across both MCMC chains and the calculation of
+  greta array values, the algorithm is run until all chains (or posterior
+  samples), sites and stages have converged to stable growth. So a single
+  value of both \code{converged} and \code{iterations} is returned, and the
+  value of this will always have the same value in an `mcmc.list` object. So
+  inspecting the MCMC trace of these parameters will only tell you whether
+  the iteration converged in \emph{all} posterior samples, and the maximum
+  number of iterations required to do so across all these samples
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test_iterate_matrix.R
+++ b/tests/testthat/test_iterate_matrix.R
@@ -9,11 +9,14 @@ test_that('single iteration works', {
   mat <- randu(n, n)
   init <- rep(1, n)
   niter <- 50
+  tol <- 1e-6
+  test_tol <- tol * 10
 
   # r version
   r_iterations <- r_iterate_matrix(matrix = mat,
                              state = init,
-                             niter = niter)
+                             niter = niter,
+                             tol = tol)
 
   target_lambda <- r_iterations$lambda
   target_stable <- r_iterations$stable_distribution
@@ -22,7 +25,8 @@ test_that('single iteration works', {
   # greta version
   iterations <- iterate_matrix(matrix = mat,
                                initial_state = init,
-                               niter = niter)
+                               niter = niter,
+                               tol = tol)
 
   lambda <- iterations$lambda
   stable <- iterations$stable_distribution
@@ -30,15 +34,15 @@ test_that('single iteration works', {
 
   greta_lambda <- calculate(lambda)
   difference <- abs(greta_lambda - target_lambda)
-  expect_true(difference < 1e-12)
+  expect_true(difference < test_tol)
 
   greta_stable <- calculate(stable)
   difference <- abs(greta_stable - target_stable)
-  expect_true(all(difference < 1e-12))
+  expect_true(all(difference < test_tol))
 
   greta_states <- calculate(states)
   difference <- abs(greta_states - target_states)
-  expect_true(all(difference < 1e-12))
+  expect_true(all(difference < test_tol))
 
 })
 
@@ -52,35 +56,33 @@ test_that('vectorised matrix iteration works', {
   mat <- randu(n_mat, n, n)
   init <- rep(1, n)
   niter <- 50
+  tol <- 1e-6
+  test_tol <- tol * 10
   mat_list <- lapply(seq_len(n_mat), function (i) mat[i, , ])
 
   # r version
   target_iterations <- lapply(mat_list,
                               r_iterate_matrix,
                               state = init,
-                              niter = niter)
+                              niter = niter,
+                              tol = tol)
 
   target_lambdas <- sapply(target_iterations, function(x) x$lambda)
   target_stable <- t(sapply(target_iterations, function(x) x$stable_distribution))
-  target_states <- lapply(target_iterations, function(x) x$all_states)
-  target_states <- do.call(abind, c(target_states, along = 0))
 
   iterations <- iterate_matrix(mat,
                                initial_state = init,
-                               niter = niter)
+                               niter = niter,
+                               tol = tol)
   greta_lambdas <- calculate(iterations$lambda)
   greta_stable <- calculate(iterations$stable_distribution)
   dim(greta_stable) <- dim(greta_stable)[1:2]
-  greta_states <- calculate(iterations$all_states)
 
   difference <- abs(greta_lambdas - target_lambdas)
-  expect_true(all(difference < 1e-12))
+  expect_true(all(difference < test_tol))
 
   difference <- abs(greta_stable - target_stable)
-  expect_true(all(difference < 1e-12))
-
-  difference <- abs(greta_states - target_states)
-  expect_true(all(difference < 1e-12))
+  expect_true(all(difference < test_tol))
 
 })
 
@@ -94,35 +96,37 @@ test_that('vectorised initial_state iteration works', {
   mat <- randu(n, n)
   init <- randu(n_mat, n, 1)
   niter <- 50
+  tol <- 1e-6
+  test_tol <- tol * 10
   init_list <- lapply(seq_len(n_mat), function (i) init[i, , ])
 
   # r version
   target_iterations <- lapply(init_list,
                               function (init) {
-                                r_iterate_matrix(mat, init, niter = niter)
+                                r_iterate_matrix(
+                                  mat,
+                                  init,
+                                  niter = niter,
+                                  tol = tol
+                                )
                               })
 
   target_lambdas <- sapply(target_iterations, function(x) x$lambda)
   target_stable <- t(sapply(target_iterations, function(x) x$stable_distribution))
-  target_states <- lapply(target_iterations, function(x) x$all_states)
-  target_states <- do.call(abind, c(target_states, along = 0))
 
   iterations <- iterate_matrix(mat,
                                initial_state = init,
-                               niter = niter)
+                               niter = niter,
+                               tol = tol)
   greta_lambdas <- calculate(iterations$lambda)
   greta_stable <- calculate(iterations$stable_distribution)
   dim(greta_stable) <- dim(greta_stable)[1:2]
-  greta_states <- calculate(iterations$all_states)
 
   difference <- abs(greta_lambdas - target_lambdas)
-  expect_true(all(difference < 1e-12))
+  expect_true(all(difference < test_tol))
 
   difference <- abs(greta_stable - target_stable)
-  expect_true(all(difference < 1e-12))
-
-  difference <- abs(greta_states - target_states)
-  expect_true(all(difference < 1e-12))
+  expect_true(all(difference < test_tol))
 
 })
 
@@ -183,5 +187,51 @@ test_that('dynamics module errors informatively', {
   expect_error(iterate_matrix(matrix = good_matrices,
                               initial_state = mismatched_state),
                'length of each initial_state must match the dimension')
+
+})
+
+test_that('convergence tolerance works', {
+
+  skip_if_not(greta:::check_tf_version())
+  source ('helpers.R')
+
+  n <- 10
+  niter <- 100
+
+  # with an identity matrix it should converge instantly
+  iterations <- iterate_matrix(matrix = diag(n))
+  converged <- calculate(iterations$converged)
+  expect_true(converged, 0L)
+
+  # with tolerance of 0, it should time out
+  iterations <- iterate_matrix(matrix = randu(n, n), tol = 0)
+  converged <- calculate(iterations$converged)
+  expect_false(converged, 1L)
+
+})
+
+test_that("iteration works in mcmc", {
+
+  skip_if_not(greta:::check_tf_version())
+  source ('helpers.R')
+
+  n <- 10
+  n_site <- 30
+
+  # non-batched case
+  mat <- uniform(0, 1, dim = c(n, n))
+  iterations <- iterate_matrix(matrix = mat)
+  lambda <- iterations$lambda
+  m <- model(lambda)
+  draws <- mcmc(m, warmup = 100, n_samples = 100, verbose = FALSE)
+  expect_s3_class(draws, "mcmc.list")
+
+  # batched case
+  mat <- uniform(0, 1, dim = c(n_site, n, n))
+  iterations <- iterate_matrix(matrix = mat)
+  lambda <- iterations$lambda
+  m <- model(lambda)
+  draws <- mcmc(m, warmup = 100, n_samples = 100, verbose = FALSE)
+  expect_s3_class(draws, "mcmc.list")
 
 })

--- a/tests/testthat/test_iterate_matrix.R
+++ b/tests/testthat/test_iterate_matrix.R
@@ -1,9 +1,9 @@
-context('iteration functions')
+context("iteration functions")
 
-test_that('single iteration works', {
+test_that("single iteration works", {
 
   skip_if_not(greta:::check_tf_version())
-  source ('helpers.R')
+  source ("helpers.R")
 
   n <- 10
   mat <- randu(n, n)
@@ -46,10 +46,10 @@ test_that('single iteration works', {
 
 })
 
-test_that('vectorised matrix iteration works', {
+test_that("vectorised matrix iteration works", {
 
   skip_if_not(greta:::check_tf_version())
-  source('helpers.R')
+  source("helpers.R")
 
   n <- 10
   n_mat <- 20
@@ -86,10 +86,10 @@ test_that('vectorised matrix iteration works', {
 
 })
 
-test_that('vectorised initial_state iteration works', {
+test_that("vectorised initial_state iteration works", {
 
   skip_if_not(greta:::check_tf_version())
-  source('helpers.R')
+  source("helpers.R")
 
   n <- 10
   n_mat <- 20
@@ -130,9 +130,9 @@ test_that('vectorised initial_state iteration works', {
 
 })
 
-test_that('dynamics module errors informatively', {
+test_that("dynamics module errors informatively", {
 
-  source ('helpers.R')
+  source ("helpers.R")
 
   n <- 10
   m <- 3
@@ -152,48 +152,48 @@ test_that('dynamics module errors informatively', {
   # wrongly shaped matrix
   expect_error(iterate_matrix(matrix = bad_mat,
                               initial_state = good_state),
-               'matrix must be a two-dimensional square greta array')
+               "matrix must be a two-dimensional square greta array")
 
   expect_error(iterate_matrix(matrix = bad_matrices1,
                               initial_state = good_state),
-               '^matrix and state must be either two- or three-dimensional')
+               "^matrix and state must be either two- or three-dimensional")
 
   expect_error(iterate_matrix(matrix = bad_matrices1,
                               initial_state = good_states),
-               '^matrix and state must be either two- or three-dimensional')
+               "^matrix and state must be either two- or three-dimensional")
 
   expect_error(iterate_matrix(matrix = bad_matrices2,
                               initial_state = good_state),
-               '^each matrix must be a two-dimensional square greta array')
+               "^each matrix must be a two-dimensional square greta array")
 
   expect_error(iterate_matrix(matrix = bad_matrices2,
                               initial_state = good_states),
-               '^each matrix must be a two-dimensional square greta array')
+               "^each matrix must be a two-dimensional square greta array")
 
   # wrongly shaped state
   expect_error(iterate_matrix(matrix = good_mat,
                               initial_state = bad_state),
-               'initial_state must be either a column vector, or a 3D array')
+               "initial_state must be either a column vector, or a 3D array")
 
   expect_error(iterate_matrix(matrix = good_matrices,
                               initial_state = bad_state),
-               'initial_state must be either a column vector, or a 3D array')
+               "initial_state must be either a column vector, or a 3D array")
 
   # mismatched matrix and state
   expect_error(iterate_matrix(matrix = good_mat,
                               initial_state = mismatched_state),
-               'length of each initial_state must match the dimension')
+               "length of each initial_state must match the dimension")
 
   expect_error(iterate_matrix(matrix = good_matrices,
                               initial_state = mismatched_state),
-               'length of each initial_state must match the dimension')
+               "length of each initial_state must match the dimension")
 
 })
 
-test_that('convergence tolerance works', {
+test_that("convergence tolerance works", {
 
   skip_if_not(greta:::check_tf_version())
-  source ('helpers.R')
+  source ("helpers.R")
 
   n <- 10
   niter <- 100
@@ -213,7 +213,7 @@ test_that('convergence tolerance works', {
 test_that("iteration works in mcmc", {
 
   skip_if_not(greta:::check_tf_version())
-  source ('helpers.R')
+  source ("helpers.R")
 
   n <- 10
   n_site <- 30


### PR DESCRIPTION
Switch to doing `iterate_matrix()` in a TF while_loop construct. This also enables setting a numerical convergence tolerance (in addition to maximum number of iterations), and reports whether or not that convergence has been reached.

Two planned additional features that are possible now we are using a while loop:
 - hot-starting the iterations (i.e. if using the default initial_state argument, on each iteration set the initial state to the final state from the previous time it was run)
 - providing an R function (converted to a tensorflow function with `greta:::as_tf_function()`) to rebuild the matrix at each iteration, given the previous state, iteration number, and any additional greta arrays.