### PR TITLE
remove transposition of transition matrix in iterate_matrix and tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: greta.dynamics
 Type: Package
 Title: Modelling Structured Dynamical Systems in greta
-Version: 0.1.0.9001
-Date: 2019-07-04
+Version: 0.1.0.9002
+Date: 2019-09-05
 Author: Nick Golding
 Maintainer: Nick Golding <nick.golding.research@gmail.com>
 Description: A greta extension module providing functions for analysing 

--- a/R/iterate_matrix.R
+++ b/R/iterate_matrix.R
@@ -3,8 +3,8 @@
 #' @title iterate transition matrices
 #'
 #' @description Calculate the intrinsic growth rate(s) and stable stage
-#'   distribution(s) for a stage-structured dynamical system, encoded as
-#'   \code{state_t = matrix %*% state_tm1}.
+#'   distribution(s) for a stage-structured dynamical system, encoded
+#'   as \code{state_t = matrix \%*\% state_tm1}.
 #'
 #' @details \code{iterate_matrix} can either act on a single transition matrix
 #'   and initial state (if \code{matrix} is 2D and \code{initial_state} is a

--- a/R/iterate_matrix.R
+++ b/R/iterate_matrix.R
@@ -3,8 +3,8 @@
 #' @title iterate transition matrices
 #'
 #' @description Calculate the intrinsic growth rate(s) and stable stage
-#'   distribution(s) for a stage-structured dynamical system, encoded as a
-#'   transition matrix.
+#'   distribution(s) for a stage-structured dynamical system, encoded as
+#'   \code{state_t = matrix %*% state_tm1}.
 #'
 #' @details \code{iterate_matrix} can either act on a single transition matrix
 #'   and initial state (if \code{matrix} is 2D and \code{initial_state} is a

--- a/R/iterate_matrix.R
+++ b/R/iterate_matrix.R
@@ -272,7 +272,7 @@ tf_iterate_matrix <- function (matrix, state, niter, tol) {
   body <- function(matrix, old_state, t_all_states, growth_rates, converged, iter, maxiter) {
 
     # do matrix multiplication
-    new_state <- tf$matmul(matrix, old_state, transpose_a = TRUE)
+    new_state <- tf$matmul(matrix, old_state, transpose_a = FALSE)
 
     # store new state object
     t_all_states <- tf$tensor_scatter_nd_update(

--- a/man/iterate_matrix.Rd
+++ b/man/iterate_matrix.Rd
@@ -42,8 +42,8 @@ a named list with five greta arrays:
 }
 \description{
 Calculate the intrinsic growth rate(s) and stable stage
-  distribution(s) for a stage-structured dynamical system, encoded as a
-  transition matrix.
+  distribution(s) for a stage-structured dynamical system, encoded
+  as \code{state_t = matrix \%*\% state_tm1}.
 }
 \details{
 \code{iterate_matrix} can either act on a single transition matrix

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -29,7 +29,7 @@ r_iterate_matrix <- function (matrix, state, niter = 100, tol = 1e-6) {
   }
 
   lambda <- states[[i]][1] / states[[i - 1]][1]
-  stable_distribution <- t(states[[i]])
+  stable_distribution <- states[[i]]
   stable_distribution <- stable_distribution / sum(stable_distribution)
   all_states <- matrix(0, ncol(matrix), niter)
   states_keep <- states[-1]

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -22,7 +22,7 @@ r_iterate_matrix <- function (matrix, state, niter = 100, tol = 1e-6) {
 
   while(i < niter & diff > tol) {
     i <- i + 1
-    states[[i + 1]] <- states[[i]] %*% matrix
+    states[[i + 1]] <- matrix %*% states[[i]]
     growth <- states[[i + 1]] / states[[i]]
     diffs <- growth - mean(growth)
     diff <- max(abs(diffs))


### PR DESCRIPTION
Following discussion in #5, set up to avoid matrix transposition in matrix multiplications. This is in line with standard usage in biology (n_{t+1} = A n_t).

Have not updated docs to reflect this. One option is to add an eqn to the `@description` of `iterate_matrix`, e.g.,
> Calculate the intrinsic growth rate(s) and stable stage distribution(s) for a stage-structured dynamical system, encoded as \code{state_t = matrix %*% state_tm1}.

Alternatively, could add this information to `@param matrix` or in `@details`.